### PR TITLE
Refactor call_user_func calls

### DIFF
--- a/src/Aggregate/EventTrackingCapabilities.php
+++ b/src/Aggregate/EventTrackingCapabilities.php
@@ -73,16 +73,24 @@ trait EventTrackingCapabilities
      */
     private function when(DomainEvent $event)
     {
-        $method = get_class($event);
+        $method = $this->getWhenMethod($event);
 
-        if (($pos = strrpos($method, '\\')) !== false) {
-            $method = substr($method, $pos + 1);
+        if (!method_exists($this, $method)) {
+            return;
         }
+        
+        $this->$method($event);
+    }
 
-        $method = 'when' . ucfirst($method);
+    /**
+     * @param DomainEvent $event
+     *
+     * @return string
+     */
+    private function getWhenMethod(DomainEvent $event)
+    {
+        $classParts = explode('\\', get_class($event));
 
-        if (is_callable([$this, $method])) {
-            call_user_func([$this, $method], $event);
-        }
+        return 'when' . ucfirst(end($classParts));
     }
 }

--- a/src/Aggregate/Factory/MappingAggregateFactory.php
+++ b/src/Aggregate/Factory/MappingAggregateFactory.php
@@ -42,7 +42,7 @@ final class MappingAggregateFactory implements ReconstitutesAggregates
         $idClass        = get_class($aggregateHistory->aggregateId());
         $aggregateClass = $this->mapIdClassToAggregateClass($idClass);
 
-        return call_user_func([$aggregateClass, 'fromHistory'], $aggregateHistory);
+        return $aggregateClass::fromHistory($aggregateHistory);
     }
 
     /**

--- a/src/Event/Wrapper/EventWrapper.php
+++ b/src/Event/Wrapper/EventWrapper.php
@@ -75,12 +75,13 @@ final class EventWrapper implements WrapsEvents
 
         $envelopes = [];
 
+        $eventEnvelopeClass = $this->eventEnvelopeClass;
+
         /** @var DomainEvent $event */
         foreach ($domainEvents as $event) {
             $aggregateVersion = ++$this->aggregateVersions[$lookupKey];
 
-            $envelopes[] = call_user_func(
-                [$this->eventEnvelopeClass, 'envelop'],
+            $envelopes[] = $eventEnvelopeClass::envelop(
                 EventId::fromString($this->identifierGenerator->generateIdentifier()),
                 $this->eventNameResolver->resolveEventName($event),
                 $event,


### PR DESCRIPTION
Improve performance by replace slow `call_user_func*` with dynamic calls.

See [jaymecd/c786005853f469b3b75d](https://gist.github.com/jaymecd/c786005853f469b3b75d) gist for benchmarking.
